### PR TITLE
Add config load and save, better default values etc.

### DIFF
--- a/bin/romanesco
+++ b/bin/romanesco
@@ -22,6 +22,8 @@ def get_argument_parser():
                        help='the number of training epochs. (default: %(default)s)')
     train.add_argument('-b', '--batch_size', type=int, default=C.BATCH_SIZE,
                        help='Number of sequences in a batch. (default: %(default)s)')
+    train.add_argument('--num_steps', type=int, default=C.NUM_STEPS,
+                       help='Max length of sequences considered for training. (default: %(default)s)')
     train.add_argument('--hidden_size', type=int, default=C.HIDDEN_SIZE,
                        help='Size of RNN hidden states. (default: %(default)s)')
     train.add_argument('--embedding_size', type=int, default=C.EMBEDDING_SIZE,

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -79,17 +79,26 @@ def action_sample(args):
     print(generated_text)
 
 
+def setup_logging(args):
+    log_level = logging.WARNING if args.quiet else logging.DEBUG
+    logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
+
+    logging.info(args)
+
+    # trying to control tensorflow logging level
+    import tensorflow as tf
+    tf.logging.set_verbosity(tf.logging.ERROR)
+
+
 def main():
     parser = get_argument_parser()
     if len(sys.argv) <= 1:
         parser.print_help()
         sys.exit()
     args = parser.parse_args()
-    # log level
-    log_level = logging.WARNING if args.quiet else logging.DEBUG
-    logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
 
-    logging.info(args)
+    setup_logging(args)
+
 
     # delegate
     if args.action == 'train':

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -52,6 +52,15 @@ def get_argument_parser():
 
 
 def action_train(args):
+    # create folders for model and logs if they don't exist yet
+    for folder in [args.save_to, args.log_to]:
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+
+    # save args for inference
+    config_path = os.path.join(args.save_to, C.CONFIG_FILENAME)
+    config.save_config(args, config_path)
+
     from romanesco.train import train
     train(**vars(args))
 
@@ -81,10 +90,6 @@ def main():
 
     # delegate
     if args.action == 'train':
-        # save args for inference
-        config_path = os.path.join(args.save_to, C.CONFIG_FILENAME)
-        config.save_config(args, config_path)
-
         action_train(args)
     else:
         # load args of trained model

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -22,9 +22,9 @@ def get_argument_parser():
                        help='the number of training epochs. (default: %(default)s)')
     train.add_argument('-b', '--batch_size', type=int, default=C.BATCH_SIZE,
                        help='Number of sequences in a batch. (default: %(default)s)')
-    train.add_argument('-b', '--hidden_size', type=int, default=C.HIDDEN_SIZE,
+    train.add_argument('--hidden_size', type=int, default=C.HIDDEN_SIZE,
                        help='Size of RNN hidden states. (default: %(default)s)')
-    train.add_argument('-b', '--embedding_size', type=int, default=C.EMBEDDING_SIZE,
+    train.add_argument('--embedding_size', type=int, default=C.EMBEDDING_SIZE,
                        help='Size of embedding vectors. (default: %(default)s)')
     train.add_argument('-v', '--vocab_max_size', type=int, default=C.VOCAB_SIZE,
                        help='Only keep n most frequent words; treat others as <unk>. (default: %(default)s)')

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -17,7 +17,7 @@ def get_argument_parser():
                         help='No logging output except for warnings and errors.')
     # train
     train = subparsers.add_parser('train', help='Train a language model.')
-    train.add_argument('data', help='the training data, a plain text file.', required=True)
+    train.add_argument('data', help='the training data, a plain text file.')
     train.add_argument('-e', '--epochs', type=int, default=C.NUM_EPOCHS,
                        help='the number of training epochs. (default: %(default)s)')
     train.add_argument('-b', '--batch_size', type=int, default=C.BATCH_SIZE,

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -79,16 +79,16 @@ def main():
 
     logging.info(args)
 
-    config_path = os.path.join(args.m, C.CONFIG_FILENAME)
-
     # delegate
     if args.action == 'train':
         # save args for inference
+        config_path = os.path.join(args.save_to, C.CONFIG_FILENAME)
         config.save_config(args, config_path)
 
         action_train(args)
     else:
         # load args of trained model
+        config_path = os.path.join(args.load_from, C.CONFIG_FILENAME)
         args = config.update_namespace_from_config(args, config_path)
 
         if args.action == 'score':

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 import logging
 import argparse
+
+from romanesco import const as C
+from romanesco import config
 
 
 def get_argument_parser():
@@ -13,30 +17,36 @@ def get_argument_parser():
                         help='No logging output except for warnings and errors.')
     # train
     train = subparsers.add_parser('train', help='Train a language model.')
-    train.add_argument('data', help='the training data, a plain text file.')
-    train.add_argument('-e', '--epochs', type=int, default=10,
-                       help='the number of training epochs.')
-    train.add_argument('-b', '--batch_size', type=int, default=20)
-    train.add_argument('-v', '--vocab_max_size', type=int, default=10000,
-                       help='Only keep n most frequent words; treat others as <unk>.')
-    train.add_argument('-m', '--save_to', default='model',
-                       help='the folder to store model files.')
-    train.add_argument('-l', '--log_to', default='logs',
-                       help='the folder to store log files. Use for monitoring with tensorboard.')
+    train.add_argument('data', help='the training data, a plain text file.', required=True)
+    train.add_argument('-e', '--epochs', type=int, default=C.NUM_EPOCHS,
+                       help='the number of training epochs. (default: %(default)s)')
+    train.add_argument('-b', '--batch_size', type=int, default=C.BATCH_SIZE,
+                       help='Number of sequences in a batch. (default: %(default)s)')
+    train.add_argument('-b', '--hidden_size', type=int, default=C.HIDDEN_SIZE,
+                       help='Size of RNN hidden states. (default: %(default)s)')
+    train.add_argument('-b', '--embedding_size', type=int, default=C.EMBEDDING_SIZE,
+                       help='Size of embedding vectors. (default: %(default)s)')
+    train.add_argument('-v', '--vocab_max_size', type=int, default=C.VOCAB_SIZE,
+                       help='Only keep n most frequent words; treat others as <unk>. (default: %(default)s)')
+    train.add_argument('-m', '--save_to', default=C.MODEL_PATH,
+                       help='the folder to store model files. (default: %(default)s)')
+    train.add_argument('-l', '--log_to', default=C.LOGS_PATH,
+                       help='the folder to store log files. Use for monitoring with tensorboard. (default: %(default)s)')
     # score
     score = subparsers.add_parser('score', help='Use a trained model to score a text.')
     score.add_argument('data', help='the data to be scored, a plain text file.')
     score.add_argument('-m', '--load_from', default='model',
-                       help='the folder to load model and vocabulary files from.')
-    score.add_argument('-b', '--batch_size', type=int, default=1)
+                       help='the folder to load model and vocabulary files from. (default: %(default)s)')
+    score.add_argument('-b', '--batch_size', type=int, default=C.BATCH_SIZE,
+                       help='Number of sequences in a batch. (default: %(default)s)')
     # sample
     sample = subparsers.add_parser('sample', help='Use a trained model to generate a new text.')
-    sample.add_argument('length', type=int, default=100, help='the number of '
-                        'symbols to be sampled, i.e., the length of the resulting text.')
-    sample.add_argument('-m', '--load_from', default='model',
-                        help='the folder to load model and vocabulary files from.')
+    sample.add_argument('length', type=int, default=C.SAMPLE_LENGTH, help='the number of '
+                        'symbols to be sampled, i.e., the length of the resulting text. (default: %(default)s)')
+    sample.add_argument('-m', '--load_from', default=C.MODEL_PATH,
+                        help='the folder to load model and vocabulary files from. (default: %(default)s)')
     sample.add_argument('-f', '--first_symbols', type=lambda s: s.split(" "), default=[],
-                        help='the first symbols of the text to be generated.')
+                        help='the first symbols of the text to be generated. (default: %(default)s)')
 
     return parser
 
@@ -58,10 +68,6 @@ def action_sample(args):
     print(generated_text)
 
 
-def action_generate(args):
-    pass
-
-
 def main():
     parser = get_argument_parser()
     if len(sys.argv) <= 1:
@@ -70,13 +76,23 @@ def main():
     # log level
     log_level = logging.WARNING if args.quiet else logging.DEBUG
     logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
+
+    config_path = os.path.join(args.m, C.CONFIG_FILENAME)
+
     # delegate
     if args.action == 'train':
+        # save args for inference
+        config.save_config(args, config_path)
+
         action_train(args)
-    elif args.action == 'score':
-        action_score(args)
-    elif args.action == 'sample':
-        action_sample(args)
+    else:
+        # load args of trained model
+        args = config.update_namespace_from_config(args, config_path)
+
+        if args.action == 'score':
+            action_score(args)
+        elif args.action == 'sample':
+            action_sample(args)
 
 
 if __name__ == '__main__':

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -9,6 +9,11 @@ from romanesco import const as C
 from romanesco import config
 
 
+# trying to control tensorflow logging level
+import tensorflow as tf
+tf.logging.set_verbosity(tf.logging.ERROR)
+
+
 def get_argument_parser():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='action', help='A vanilla recurrent '
@@ -84,10 +89,6 @@ def setup_logging(args):
     logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
 
     logging.info(args)
-
-    # trying to control tensorflow logging level
-    import tensorflow as tf
-    tf.logging.set_verbosity(tf.logging.ERROR)
 
 
 def main():

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -77,6 +77,8 @@ def main():
     log_level = logging.WARNING if args.quiet else logging.DEBUG
     logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
 
+    logging.info(args)
+
     config_path = os.path.join(args.m, C.CONFIG_FILENAME)
 
     # delegate

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -12,7 +12,7 @@ from romanesco import config
 def get_argument_parser():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='action', help='A vanilla recurrent '
-                                       'neural network (RNN) language model')
+                                       'neural network (RNN) language model', required=True)
     parser.add_argument('-q', '--quiet', action='store_true',
                         help='No logging output except for warnings and errors.')
     # train

--- a/bin/romanesco
+++ b/bin/romanesco
@@ -12,7 +12,7 @@ from romanesco import config
 def get_argument_parser():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='action', help='A vanilla recurrent '
-                                       'neural network (RNN) language model', required=True)
+                                       'neural network (RNN) language model')
     parser.add_argument('-q', '--quiet', action='store_true',
                         help='No logging output except for warnings and errors.')
     # train
@@ -81,6 +81,7 @@ def main():
     parser = get_argument_parser()
     if len(sys.argv) <= 1:
         parser.print_help()
+        sys.exit()
     args = parser.parse_args()
     # log level
     log_level = logging.WARNING if args.quiet else logging.DEBUG

--- a/romanesco/compgraph.py
+++ b/romanesco/compgraph.py
@@ -1,30 +1,32 @@
 #!/usr/bin/env python3
 
-import numpy as np
 import tensorflow as tf
-import tensorflow.contrib.layers as layers
 from tensorflow.python.ops.functional_ops import map_fn
 
 from romanesco import const as C
 
 
-def define_computation_graph(vocab_size: int, batch_size: int):
+def define_computation_graph(vocab_size: int = C.VOCAB_SIZE,
+                             batch_size: int = C.BATCH_SIZE,
+                             num_steps: int = C.NUM_STEPS,
+                             hidden_size: int = C.HIDDEN_SIZE,
+                             embedding_size: int = C.EMBEDDING_SIZE):
 
     # Placeholders for input and output
-    inputs = tf.placeholder(tf.int32, shape=(batch_size, C.NUM_STEPS), name='x')  # (time, batch)
-    targets = tf.placeholder(tf.int32, shape=(batch_size, C.NUM_STEPS), name='y') # (time, batch)
+    inputs = tf.placeholder(tf.int32, shape=(batch_size, num_steps), name='x')  # (batch, time)
+    targets = tf.placeholder(tf.int32, shape=(batch_size, num_steps), name='y') # (batch, time)
 
     with tf.name_scope('Embedding'):
-        embedding = tf.get_variable('word_embedding', [vocab_size, C.HIDDEN_SIZE])
+        embedding = tf.get_variable('word_embedding', [vocab_size, embedding_size])
         input_embeddings = tf.nn.embedding_lookup(embedding, inputs)
 
     with tf.name_scope('RNN'):
-        cell = tf.nn.rnn_cell.BasicLSTMCell(C.HIDDEN_SIZE, state_is_tuple=True)
+        cell = tf.nn.rnn_cell.BasicLSTMCell(hidden_size, state_is_tuple=True)
         initial_state = cell.zero_state(batch_size, tf.float32)
         rnn_outputs, rnn_states = tf.nn.dynamic_rnn(cell, input_embeddings, initial_state=initial_state)
 
     with tf.name_scope('Final_Projection'):
-        w = tf.get_variable('w', shape=(C.HIDDEN_SIZE, vocab_size))
+        w = tf.get_variable('w', shape=(hidden_size, vocab_size))
         b = tf.get_variable('b', vocab_size)
         final_projection = lambda x: tf.matmul(x, w) + b
         logits = map_fn(final_projection, rnn_outputs)
@@ -33,7 +35,7 @@ def define_computation_graph(vocab_size: int, batch_size: int):
         # weighted average cross-entropy (log-perplexity) per symbol
         loss = tf.contrib.seq2seq.sequence_loss(logits=logits,
                                                 targets=targets,
-                                                weights=tf.ones([batch_size, C.NUM_STEPS]),
+                                                weights=tf.ones([batch_size, num_steps]),
                                                 average_across_timesteps=True,
                                                 average_across_batch=True)
 

--- a/romanesco/config.py
+++ b/romanesco/config.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import json
+import argparse
+
+
+def save_config(args: argparse.Namespace,
+                config_path: str):
+
+    with open(config_path, "w") as f:
+        json.dump(vars(args), f, indent=4)
+
+
+def update_namespace_from_config(args: argparse.Namespace,
+                                 config_path: str):
+
+    with open(config_path, "r") as f:
+        for key, value in json.load(f).items():
+            args[key] = value
+
+    return args

--- a/romanesco/config.py
+++ b/romanesco/config.py
@@ -20,7 +20,7 @@ def update_namespace_from_config(args: argparse.Namespace,
 
     args_dict = vars(args)
 
-    updateable_args = ["hidden_size", "embedding_size", "vocab_max_size"]
+    updateable_args = ["hidden_size", "embedding_size", "vocab_max_size", "num_steps"]
 
     with open(config_path, "r") as f:
         for key, value in json.load(f).items():

--- a/romanesco/config.py
+++ b/romanesco/config.py
@@ -27,4 +27,6 @@ def update_namespace_from_config(args: argparse.Namespace,
             if key in updateable_args:
                 args_dict[key] = value
 
+    logging.info("Config after updating from '%s': %s", config_path, args)
+
     return args

--- a/romanesco/config.py
+++ b/romanesco/config.py
@@ -2,10 +2,12 @@
 
 import json
 import argparse
-
+import logging
 
 def save_config(args: argparse.Namespace,
                 config_path: str):
+
+    logging.info("Saving model config to '%s'." % config_path)
 
     with open(config_path, "w") as f:
         json.dump(vars(args), f, indent=4)
@@ -14,10 +16,15 @@ def save_config(args: argparse.Namespace,
 def update_namespace_from_config(args: argparse.Namespace,
                                  config_path: str):
 
+    logging.info("Loading model config from '%s'." % config_path)
+
     args_dict = vars(args)
+
+    updateable_args = ["hidden_size", "embedding_size", "vocab_max_size"]
 
     with open(config_path, "r") as f:
         for key, value in json.load(f).items():
-            args_dict[key] = value
+            if key in updateable_args:
+                args_dict[key] = value
 
     return args

--- a/romanesco/config.py
+++ b/romanesco/config.py
@@ -14,8 +14,10 @@ def save_config(args: argparse.Namespace,
 def update_namespace_from_config(args: argparse.Namespace,
                                  config_path: str):
 
+    args_dict = vars(args)
+
     with open(config_path, "r") as f:
         for key, value in json.load(f).items():
-            args[key] = value
+            args_dict[key] = value
 
     return args

--- a/romanesco/const.py
+++ b/romanesco/const.py
@@ -14,14 +14,14 @@ VOCAB_FILENAME = 'vocab.json'
 CONFIG_FILENAME = 'config.json'
 
 VOCAB_SIZE = 10000
-BATCH_SIZE = 20
+BATCH_SIZE = 64
 
 NUM_EPOCHS = 10
 
 # num_steps and learning_rate are hardcoded here; at the moment,
 # the only way to change them is to edit this file
-NUM_STEPS = 35 # truncated backprop length
-LEARNING_RATE = 0.0001
+NUM_STEPS = 100 # truncated backprop length
+LEARNING_RATE = 0.001
 
 HIDDEN_SIZE = 1024  # RNN state size
 EMBEDDING_SIZE = 256  # embedding vector size

--- a/romanesco/const.py
+++ b/romanesco/const.py
@@ -3,10 +3,27 @@
 EOS = '<eos>'
 UNK = '<unk>'
 
+# default values
+
+MODEL_PATH = "model"
+LOGS_PATH = "logs"
+
 MODEL_FILENAME = 'model'
 VOCAB_FILENAME = 'vocab.json'
 
-# Ugly hardcoded hyperparameters
+CONFIG_FILENAME = 'config.json'
+
+VOCAB_SIZE = 10000
+BATCH_SIZE = 20
+
+NUM_EPOCHS = 10
+
+# num_steps and learning_rate are hardcoded here; at the moment,
+# the only way to change them is to edit this file
 NUM_STEPS = 35 # truncated backprop length
 LEARNING_RATE = 0.0001
-HIDDEN_SIZE = 1500 # layer size
+
+HIDDEN_SIZE = 1024  # RNN state size
+EMBEDDING_SIZE = 256  # embedding vector size
+
+SAMPLE_LENGTH = 100

--- a/romanesco/reader.py
+++ b/romanesco/reader.py
@@ -34,7 +34,9 @@ def read(filename: str, vocab):
     return [vocab.get_id(word) for word in words]
 
 
-def iterate(raw_data, batch_size: int, num_steps: int):
+def iterate(raw_data,
+            batch_size: int = C.BATCH_SIZE,
+            num_steps: int = C.NUM_STEPS):
     """Yields sequences of length `num_step` for RNN training (or evaluation),
     in batches of size `batch_size`.
 

--- a/romanesco/sample.py
+++ b/romanesco/sample.py
@@ -19,14 +19,22 @@ def softmax(x):
     return np.exp(x) / np.sum(np.exp(x), axis=0)
 
 
-def sample(length: int, load_from: str, first_symbols: List[str] = [], **kwargs):
+def sample(length: int = C.SAMPLE_LENGTH,
+           load_from: str = C.MODEL_PATH,
+           first_symbols: List[str] = [],
+           hidden_size: int = C.HIDDEN_SIZE,
+           embedding_size: int = C.EMBEDDING_SIZE,
+           **kwargs):
     """Generates a text by sampling from a trained language model. See argument
     description in `bin/romanesco`."""
 
     vocab = Vocabulary()
-    vocab.load(os.path.join(load_from, 'vocab.json'))
+    vocab.load(os.path.join(load_from, C.VOCAB_FILENAME))
 
-    inputs, targets, _, _, logits, _ = define_computation_graph(vocab.size, 1)
+    inputs, targets, _, _, logits, _ = define_computation_graph(vocab_size=vocab.size,
+                                                              batch_size=1,
+                                                              hidden_size=hidden_size,
+                                                              embedding_size=embedding_size)
 
     saver = tf.train.Saver()
 

--- a/romanesco/sample.py
+++ b/romanesco/sample.py
@@ -66,7 +66,7 @@ def sample(length: int = C.SAMPLE_LENGTH,
         for _ in range(length):
             sampled_sequence.append(sampled_symbol)
             x = np.roll(x, -1)
-            x[C.NUM_STEPS - 1] = sampled_symbol
+            x[num_steps - 1] = sampled_symbol
             l = session.run([logits], feed_dict={inputs: [x], targets: [y]})
             next_symbol_logits = l[0][0][-1] # first returned session variable, first batch, last symbol
             next_symbol_probs = softmax(next_symbol_logits)
@@ -81,4 +81,9 @@ def sample(length: int = C.SAMPLE_LENGTH,
                     sampled_symbol = np.random.choice(range(vocab.size), p=next_symbol_probs)
 
     words = vocab.get_words(sampled_sequence)
-    return ' '.join(words).replace(' ' + C.EOS + ' ', '\n') # OPTIMIZE: remove <eos> at the very end
+
+    for index, word in enumerate(words):
+        if word == C.EOS:
+            words[index] = "\n"
+
+    return ' '.join(words)

--- a/romanesco/sample.py
+++ b/romanesco/sample.py
@@ -24,6 +24,7 @@ def sample(length: int = C.SAMPLE_LENGTH,
            first_symbols: List[str] = [],
            hidden_size: int = C.HIDDEN_SIZE,
            embedding_size: int = C.EMBEDDING_SIZE,
+           num_steps: int = C.NUM_STEPS,
            **kwargs):
     """Generates a text by sampling from a trained language model. See argument
     description in `bin/romanesco`."""
@@ -32,9 +33,10 @@ def sample(length: int = C.SAMPLE_LENGTH,
     vocab.load(os.path.join(load_from, C.VOCAB_FILENAME))
 
     inputs, targets, _, _, logits, _ = define_computation_graph(vocab_size=vocab.size,
-                                                              batch_size=1,
-                                                              hidden_size=hidden_size,
-                                                              embedding_size=embedding_size)
+                                                               batch_size=1,
+                                                               num_steps=num_steps,
+                                                               hidden_size=hidden_size,
+                                                               embedding_size=embedding_size)
 
     saver = tf.train.Saver()
 
@@ -54,8 +56,8 @@ def sample(length: int = C.SAMPLE_LENGTH,
             # if no prime text, then just sample a single symbol
             first_symbol_ids = [vocab.get_random_id()]
 
-        x = np.array(np.zeros(C.NUM_STEPS, dtype=int)) # padding with zeros (UNK)
-        y = np.array(np.zeros(C.NUM_STEPS, dtype=int)) # we don't care about gold targets here
+        x = np.array(np.zeros(num_steps, dtype=int)) # padding with zeros (UNK)
+        y = np.array(np.zeros(num_steps, dtype=int)) # we don't care about gold targets here
 
         UNK_ID = vocab.get_id(C.UNK)
 

--- a/romanesco/score.py
+++ b/romanesco/score.py
@@ -17,6 +17,7 @@ def score(data: str,
           batch_size: int = C.BATCH_SIZE,
           hidden_size: int = C.HIDDEN_SIZE,
           embedding_size: int = C.EMBEDDING_SIZE,
+          num_steps: int = C.NUM_STEPS,
           **kwargs):
     """Scores a text using a trained language model. See argument description in `bin/romanesco`."""
 
@@ -27,6 +28,7 @@ def score(data: str,
 
     inputs, targets, loss, _, _, _ = define_computation_graph(vocab_size=vocab.size,
                                                               batch_size=batch_size,
+                                                              num_steps=num_steps,
                                                               hidden_size=hidden_size,
                                                               embedding_size=embedding_size)
 
@@ -38,7 +40,7 @@ def score(data: str,
 
         total_loss = 0.0
         total_iter = 0
-        for x, y in reader.iterate(raw_data, batch_size, C.NUM_STEPS):
+        for x, y in reader.iterate(raw_data, batch_size, num_steps):
             l = session.run([loss], feed_dict={inputs: x, targets: y})
             total_loss += l[0]
             total_iter += 1

--- a/romanesco/score.py
+++ b/romanesco/score.py
@@ -7,30 +7,38 @@ import numpy as np
 import tensorflow as tf
 
 from romanesco import reader
-from romanesco.const import *
+from romanesco import const as C
 from romanesco.vocab import Vocabulary
 from romanesco.compgraph import define_computation_graph
 
 
-def score(data: str, load_from: str, batch_size: int, **kwargs):
+def score(data: str,
+          load_from: str = C.MODEL_PATH,
+          batch_size: int = C.BATCH_SIZE,
+          hidden_size: int = C.HIDDEN_SIZE,
+          embedding_size: int = C.EMBEDDING_SIZE,
+          **kwargs):
     """Scores a text using a trained language model. See argument description in `bin/romanesco`."""
 
     vocab = Vocabulary()
-    vocab.load(os.path.join(load_from, 'vocab.json'))
+    vocab.load(os.path.join(load_from, C.VOCAB_FILENAME))
 
     raw_data = reader.read(data, vocab)
 
-    inputs, targets, loss, _, _, _ = define_computation_graph(vocab.size, batch_size)
+    inputs, targets, loss, _, _, _ = define_computation_graph(vocab_size=vocab.size,
+                                                              batch_size=batch_size,
+                                                              hidden_size=hidden_size,
+                                                              embedding_size=embedding_size)
 
     saver = tf.train.Saver()
 
     with tf.Session() as session:
         # load model
-        saver.restore(session, os.path.join(load_from, MODEL_FILENAME))
+        saver.restore(session, os.path.join(load_from, C.MODEL_FILENAME))
 
         total_loss = 0.0
         total_iter = 0
-        for x, y in reader.iterate(raw_data, batch_size, NUM_STEPS):
+        for x, y in reader.iterate(raw_data, batch_size, C.NUM_STEPS):
             l = session.run([loss], feed_dict={inputs: x, targets: y})
             total_loss += l[0]
             total_iter += 1

--- a/romanesco/score.py
+++ b/romanesco/score.py
@@ -25,14 +25,13 @@ def score(data: str,
     vocab.load(os.path.join(load_from, C.VOCAB_FILENAME))
 
     raw_data = reader.read(data, vocab)
+    data_length = len(raw_data)
 
-    if len(raw_data) < num_steps:
-        logging.warning("Length of input data is shorter than NUM_STEPS. Will pad input with <unk>.")
-        # Source: https://stackoverflow.com/a/39923577/1987598
-        unk_id = vocab.get_id(C.UNK)
-        raw_data = (raw_data + num_steps * [unk_id])[:num_steps]
+    if data_length < num_steps:
+        logging.warning("Length of input data is shorter than NUM_STEPS. Will try to reduce NUM_STEPS.")
+        num_steps = data_length - 1
 
-    if len(raw_data) < batch_size * num_steps:
+    if data_length < batch_size * num_steps:
         logging.warning("Length of input data is shorter than BATCH_SIZE * NUM_STEPS. Will try to set batch size to 1.")
         batch_size = 1
 

--- a/romanesco/score.py
+++ b/romanesco/score.py
@@ -26,6 +26,16 @@ def score(data: str,
 
     raw_data = reader.read(data, vocab)
 
+    if len(raw_data) < num_steps:
+        logging.warning("Length of input data is shorter than NUM_STEPS. Will pad input with <unk>.")
+        # Source: https://stackoverflow.com/a/39923577/1987598
+        unk_id = vocab.get_id(C.UNK)
+        raw_data = (raw_data + num_steps * [unk_id])[:num_steps]
+
+    if len(raw_data) < batch_size * num_steps:
+        logging.warning("Length of input data is shorter than BATCH_SIZE * NUM_STEPS. Will try to set batch size to 1.")
+        batch_size = 1
+
     inputs, targets, loss, _, _, _ = define_computation_graph(vocab_size=vocab.size,
                                                               batch_size=batch_size,
                                                               num_steps=num_steps,

--- a/romanesco/train.py
+++ b/romanesco/train.py
@@ -21,6 +21,7 @@ def train(data: str,
           vocab_max_size: int = C.VOCAB_SIZE,
           save_to: str = C.MODEL_PATH,
           log_to: str = C.LOGS_PATH,
+          num_steps: int = C.NUM_STEPS,
           **kwargs):
     """Trains a language model. See argument description in `bin/romanesco`."""
 
@@ -35,6 +36,7 @@ def train(data: str,
     # define computation graph
     inputs, targets, loss, train_step, _, summary = define_computation_graph(vocab_size=vocab.size,
                                                                              batch_size=batch_size,
+                                                                             num_steps=num_steps,
                                                                              hidden_size=hidden_size,
                                                                              embedding_size=embedding_size)
 

--- a/romanesco/train.py
+++ b/romanesco/train.py
@@ -24,11 +24,6 @@ def train(data: str,
           **kwargs):
     """Trains a language model. See argument description in `bin/romanesco`."""
 
-    # create folders for model and logs if they don't exist yet
-    for folder in [save_to, log_to]:
-        if not os.path.exists(folder):
-            os.makedirs(folder)
-
     # create vocabulary to map words to ids
     vocab = Vocabulary()
     vocab.build(data, max_size=vocab_max_size)

--- a/romanesco/train.py
+++ b/romanesco/train.py
@@ -13,8 +13,15 @@ from romanesco.compgraph import define_computation_graph
 from romanesco import const as C
 
 
-def train(data: str, epochs: int, batch_size: int, vocab_max_size: int,
-          save_to: str, log_to: str, **kwargs):
+def train(data: str,
+          epochs: int = C.NUM_EPOCHS,
+          batch_size: int = C.BATCH_SIZE,
+          hidden_size: int = C.HIDDEN_SIZE,
+          embedding_size: int = C.EMBEDDING_SIZE,
+          vocab_max_size: int = C.VOCAB_SIZE,
+          save_to: str = C.MODEL_PATH,
+          log_to: str = C.LOGS_PATH,
+          **kwargs):
     """Trains a language model. See argument description in `bin/romanesco`."""
 
     # create folders for model and logs if they don't exist yet
@@ -31,7 +38,10 @@ def train(data: str, epochs: int, batch_size: int, vocab_max_size: int,
     raw_data = reader.read(data, vocab)
 
     # define computation graph
-    inputs, targets, loss, train_step, _, summary = define_computation_graph(vocab.size, batch_size)
+    inputs, targets, loss, train_step, _, summary = define_computation_graph(vocab_size=vocab.size,
+                                                                             batch_size=batch_size,
+                                                                             hidden_size=hidden_size,
+                                                                             embedding_size=embedding_size)
 
     saver = tf.train.Saver()
 

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ def readme():
         return f.read()
 
 setup(name='romanesco',
-    version='0.1',
+    version='0.2',
     description='A vanilla recurrent neural network (RNN) language model',
-    url='http://github.com/laeubli/romanesco',
-    author='Samuel Läubli',
-    author_email='laeubli@cl.uzh.ch',
+    url='http://github.com/zurichnlp/romanesco',
+    author='Samuel Läubli, Mathias Müller',
+    author_email='laeubli@cl.uzh.ch, mmueller@cl.uzh.ch',
     license='LGPL',
     packages=['romanesco'],
     scripts=['bin/romanesco'],

--- a/utils/chars2words.py
+++ b/utils/chars2words.py
@@ -1,0 +1,22 @@
+#! /usr/bin/python3
+
+import sys
+
+for line in sys.stdin:
+
+    line = line.strip()
+
+    chars = line.split(" ")
+
+    words = []
+    word = []
+    for char in chars:
+        if char == "<space>":
+            words.append("".join(word))
+            word = []
+            continue
+        elif char == " ":
+            continue
+        word.append(char)
+
+    sys.stdout.write(" ".join(words) + "\n")

--- a/utils/words2chars.py
+++ b/utils/words2chars.py
@@ -1,0 +1,14 @@
+#! /usr/bin/python3
+
+import sys
+
+for line in sys.stdin:
+    line = line.strip()
+
+    charred_words = []
+
+    for word in line.split(" "):
+        chars = list(word)
+        charred_words.append(" ".join(chars))
+
+    sys.stdout.write(" <space> ".join(charred_words) + "\n")


### PR DESCRIPTION
Changes:
- facilitating the use of romanesco in Jupyter notebooks /Colab, e.g. by shifting focus away from command line usage
- training saves an args config that can be loaded later. This makes model parameters (like hidden size) configurable.
- more args, better default values for them
- make scoring work for short inputs
- turn off tensorflow debug logging that is filling the screen with newer versions of TF
- utils to convert word training data to chars and vice versa